### PR TITLE
`Mulligan::Kernel#raise` now raises with the same stack frame

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,12 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
+require "rake/extensiontask"
+
+Rake::ExtensionTask.new "mulligan" do |ext|
+  ext.lib_dir = "lib/mulligan"
+end
+
+RSpec::Core::RakeTask.new(:spec => :compile)
 
 task :default => :spec

--- a/ext/mulligan/extconf.rb
+++ b/ext/mulligan/extconf.rb
@@ -1,0 +1,3 @@
+require "mkmf"
+
+create_makefile "mulligan/mulligan"

--- a/ext/mulligan/mulligan.c
+++ b/ext/mulligan/mulligan.c
@@ -1,0 +1,175 @@
+#include <ruby.h>
+
+
+// -----------------------------------------------------------
+//  UTILITIES
+// -----------------------------------------------------------
+
+#define ARRAY_SIZE(var) (sizeof(var)/sizeof(var[0]))
+
+// -----------------------------------------------------------
+//  DECLARATIONS
+// -----------------------------------------------------------
+
+static VALUE rb_mulligan_raise(int argc, VALUE *argv, VALUE self);
+static VALUE callcc_block(VALUE c, VALUE in_context, int argc, VALUE argv[]);
+static VALUE __set_continuation__block(VALUE unused, VALUE in_context, int argc, VALUE argv[]);
+
+static ID id_recoveries = 0;
+static ID id_empty_ = 0;
+static ID id_send = 0;
+static ID id_callcc = 0;
+static ID id_call = 0;
+static ID id___set_continuation__ = 0;
+static ID id_puts = 0;
+
+// ===========================================================
+//  MAIN ENTRY POINT
+// ===========================================================
+
+void Init_mulligan(void)
+{
+  VALUE mMulligan = rb_define_module("Mulligan");
+  VALUE mKernel = rb_define_module_under(mMulligan, "Kernel");
+  rb_define_method(mKernel, "raise", rb_mulligan_raise, -1);
+
+  rb_require("continuation");
+  id_recoveries = rb_intern("recoveries");
+  id_empty_ = rb_intern("empty?");
+  id_send = rb_intern("send");
+  id_callcc = rb_intern("callcc");
+  id_call = rb_intern("call");
+  id___set_continuation__ = rb_intern("__set_continuation__");
+  id_puts = rb_intern("puts");
+}
+
+
+/* -----------------------------------------------------------
+//  Here is the template ruby code that we are approximating
+//  in C. Native-only calls are surround by <<>>
+// -----------------------------------------------------------
+def raise(*args)
+  e = <<make_exception(*args)>>
+  yield e if block_given?
+
+  # only use callcc if there are restarts otherwise re-raise it
+  <<rb_exc_raise(e)>> if e.send(:recoveries).empty?
+  should_raise = true
+  result = callcc do |c|
+    e.send(:__set_continuation__) do |*args,&block|
+      should_raise = false
+      c.call(*args,&block)
+    end
+  end
+  <<rb_exc_raise(e)>> if should_raise
+  result
+end
+// -----------------------------------------------------------
+// There is one big difference which is at all costs, we only
+// call `rb_exc_raise` from the current frame. This is important
+// because we want the stack-trace and current stack-frame to
+// be identical to what they were if we just called the standard
+// #raise method. If we call `rb_exc_raise` within a block or
+// call super, we will lose that stack-frame context.
+// For this reason, you'll see that awkward `should_raise` variable
+// in the source above.
+// -----------------------------------------------------------*/
+
+
+static VALUE
+rb_mulligan_raise(int argc, VALUE *argv, VALUE self)
+{
+    // -----------------------------------------------------------
+    //  Get a reference to the Exception object
+    // -----------------------------------------------------------
+    VALUE e = rb_make_exception(argc, argv);
+    
+    // -----------------------------------------------------------
+    //  With the Exception in place, yield to the block
+    // -----------------------------------------------------------
+    if (rb_block_given_p())
+      rb_yield(e);
+
+    // -----------------------------------------------------------
+    //  If there are no recoveries, just throw it without a callcc
+    // -----------------------------------------------------------
+    VALUE recoveries = rb_funcall(e, id_send, 1, ID2SYM(id_recoveries));
+    VALUE is_empty = rb_funcall(recoveries, id_empty_, 0);
+    if (RTEST(is_empty))
+        goto raise;
+    
+    // -----------------------------------------------------------
+    //  There are recoveries so we first capture the continuation
+    //  using callcc
+    // -----------------------------------------------------------
+
+    // A note about should_raise_ary:
+    // 2 callbacks from now (in `__set_continuation__block`) we are
+    // going to want to change the value of this from true to false. Since Qtrue
+    // is not a pointer, we are going to make a ghetto-pointer by putting it in
+    // an array of one. That array will be passed to the callback where it will be
+    // modified and we can read it still in this context after all the callbacks
+    // are complete.
+    VALUE should_raise_ary = rb_ary_to_ary(Qtrue);
+
+    VALUE contextVars[] = {self, should_raise_ary, e};
+    VALUE context = rb_ary_new4(ARRAY_SIZE(contextVars), contextVars);
+    
+    VALUE result = rb_block_call(
+        self,
+        id_callcc,
+        0, // argc
+        0, // argv
+        RUBY_METHOD_FUNC(callcc_block),
+        context
+        );
+
+    // Here we read our "pointer"
+    if (!RTEST(rb_ary_entry(should_raise_ary, 0)))
+      return result;
+
+raise:
+    rb_exc_raise(e);
+    UNREACHABLE;
+}
+
+static VALUE
+callcc_block(VALUE c, VALUE in_context, int argc, VALUE argv[])
+{
+    VALUE self =             rb_ary_entry(in_context, 0);
+    VALUE should_raise_ary = rb_ary_entry(in_context, 1);
+    VALUE e =                rb_ary_entry(in_context, 2);
+
+    VALUE contextVars[] = {self, should_raise_ary, c};
+    VALUE context = rb_ary_new4(ARRAY_SIZE(contextVars), contextVars);
+    VALUE block_argv[1] = {ID2SYM(id___set_continuation__)};
+
+    return rb_block_call(
+        e,
+        id___set_continuation__,
+        0, // argc
+        0, // argv
+        RUBY_METHOD_FUNC(__set_continuation__block),
+        context // data2
+        );
+}
+
+static VALUE
+__set_continuation__block(VALUE unused, VALUE in_context, int argc, VALUE argv[])
+{
+    VALUE self =             rb_ary_entry(in_context, 0);
+    VALUE should_raise_ary = rb_ary_entry(in_context, 1);
+    VALUE c =                rb_ary_entry(in_context, 2);
+
+    // Here we set our `should_raise` pointer back to false
+    rb_ary_store(should_raise_ary, 0, Qfalse);
+    
+    VALUE proc = rb_block_proc();
+    
+    return rb_funcall_with_block(c, id_call, argc, argv, proc);
+}
+
+
+
+
+

--- a/lib/mulligan/condition.rb
+++ b/lib/mulligan/condition.rb
@@ -1,5 +1,3 @@
-require 'continuation'
-
 module Mulligan
 
   # An exception that is thrown when invoking a non-existent recovery.
@@ -66,7 +64,7 @@ module Mulligan
         return
       end
       Thread.current[:__last_recovery__] = id
-      data[:continuation].call(data[:block].call(*params))
+      data[:continuation].call(*data[:block].call(*params))
     end
   
   private
@@ -75,7 +73,8 @@ module Mulligan
       @recoveries ||= {}
     end
 
-    def __set_continuation__(continuation)
+    def __set_continuation__
+      continuation = Proc.new
       # the the continuation for any recoveries that are not yet assigned one
       # It's important not to overwrite the existing continuations because a recovery
       # should return to the place it was raised, always.

--- a/lib/mulligan/kernel.rb
+++ b/lib/mulligan/kernel.rb
@@ -1,30 +1,4 @@
-module Mulligan
-  module Kernel
+require "mulligan/mulligan"
+require_relative 'kernel_common'
 
-    # Raises an Exception.
-    # The Exception that is either passed in or generated is yielded to the block
-    # where you can specify recoveries on it.
-    # 
-    # @param args the same args you would pass to the normal Kernel#raise
-    # @yield [e] Passes the exception-to-be-raised to the block.
-    # @return The value returned from the invoked recovery block.
-    def raise(*args, &block)
-      super
-    rescue Exception => e
-      block.call(e) unless block.nil?
-
-      # only use callcc if there are restarts otherwise re-raise it
-      super(e) if e.send(:recoveries).empty?
-      callcc do |c|
-        e.send(:__set_continuation__, c)
-        super(e)
-      end
-    end
-    
-    # Returns the identifier for the last recovery invoked in this thread.
-    # @return [Symbol] The identifier of the last recovery invoked in this thread.
-    def last_recovery
-      Thread.current[:__last_recovery__]
-    end
-  end
-end
+# raise is implemented by the c-extension

--- a/lib/mulligan/kernel_common.rb
+++ b/lib/mulligan/kernel_common.rb
@@ -1,0 +1,12 @@
+require 'continuation'
+
+module Mulligan
+  module Kernel
+
+    # Returns the identifier for the last recovery invoked in this thread.
+    # @return [Symbol] The identifier of the last recovery invoked in this thread.
+    def last_recovery
+      Thread.current[:__last_recovery__]
+    end
+  end
+end

--- a/lib/mulligan/kernel_pure.rb
+++ b/lib/mulligan/kernel_pure.rb
@@ -1,0 +1,31 @@
+require_relative 'kernel_common'
+
+module Mulligan
+  module Kernel
+
+    # Raises an Exception.
+    # The Exception that is either passed in or generated is yielded to the block
+    # where you can specify recoveries on it.
+    # 
+    # @param args the same args you would pass to the normal Kernel#raise
+    # @yield [e] Passes the exception-to-be-raised to the block.
+    # @return The value returned from the invoked recovery block.
+    def raise(*args)
+      super
+    rescue Exception => e
+      yield e if block_given?
+
+      # only use callcc if there are restarts otherwise re-raise it
+      super(e) if e.send(:recoveries).empty?
+      should_raise = true
+      result = callcc do |c|
+        e.send(:__set_continuation__) do |*args,&block|
+          should_raise = false
+          c.call(*args,&block)
+        end
+      end
+      super(e) if should_raise
+      result
+    end
+  end
+end

--- a/mulligan.gemspec
+++ b/mulligan.gemspec
@@ -19,6 +19,7 @@ __END__
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
+  spec.extensions    = %w[ext/mulligan/extconf.rb]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
@@ -26,4 +27,5 @@ __END__
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rake-compiler"
 end

--- a/spec/mulligan_spec.rb
+++ b/spec/mulligan_spec.rb
@@ -141,6 +141,24 @@ describe Mulligan do
         expect(e.has_recovery?:ignore).to be_true
       end
     end
+
+    it "should properly report the line when raising with no block" do
+      begin
+        line = __LINE__ ; raise "Test"
+      rescue => e
+        expect(line_from_stack_string(e.backtrace[0])).to eq(line)
+      end
+    end
+
+    it "should properly report the line when raising WITH a block" do
+      begin
+        line = __LINE__ ; raise "Test" do |e|
+          false
+        end
+      rescue => e
+        expect(line_from_stack_string(e.backtrace[0])).to eq(line)
+      end
+    end
   end
 end
 
@@ -148,6 +166,11 @@ end
 #=======================
 #    HELPER METHODS
 #=======================
+
+# returns the line given a string from Exception#backtrace
+def line_from_stack_string(s)
+  s.match(/[^:]+:(\d+)/)[1].to_i
+end
 
 def core_test(style)
   t =  "Test Exception"


### PR DESCRIPTION
as `Kernel#raise` as it is implemented with a c-extension.
Still only compatible with MRI 2.x
